### PR TITLE
CATL-1381: Add Related Relationship Functionality For Profile Blocks

### DIFF
--- a/CRM/Contactlayout/Form/Inline/ProfileBlock.php
+++ b/CRM/Contactlayout/Form/Inline/ProfileBlock.php
@@ -13,8 +13,12 @@ class CRM_Contactlayout_Form_Inline_ProfileBlock extends CRM_Profile_Form_Edit {
    * Form for editing profile blocks
    */
   public function preProcess() {
-    if (!empty($_GET['cid'])) {
-      $this->set('id', $_GET['cid']);
+    $relatedContactId = CRM_Utils_Request::retrieveValue('rel_cid', 'Positive', NULL, FALSE);
+    $viewedContactId = CRM_Utils_Request::retrieveValue('cid', 'Positive', NULL, TRUE);
+    $contactId = $relatedContactId ? $relatedContactId : $viewedContactId;
+
+    if (!empty($contactId)) {
+      $this->set('id', $contactId);
     }
     parent::preProcess();
     // Suppress profile status messages like the double-opt-in warning

--- a/CRM/Contactlayout/Helper/ProfileRelatedContact.php
+++ b/CRM/Contactlayout/Helper/ProfileRelatedContact.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Class CRM_Contactlayout_Helper_ProfileRelatedContact.
+ */
+class CRM_Contactlayout_Helper_ProfileRelatedContact {
+
+  /**
+   * Returns the contact that has the related relationship with the passed contact.
+   *
+   * The first related contact is simply returned even if there are more than
+   * one contact that meets the relationship criteria with the passed in contact.
+   *
+   * @param int $contactId
+   *   Contact to get related contact for.
+   * @param string $relatedRelationship
+   *   String defining relationship to check for with passed contact
+   *   e.g `16_ab` means relationship type id 16 and relationship direction is ab.
+   *
+   * @return int|null
+   *   The first contact matching the criteria.
+   */
+  public static function get($contactId, $relatedRelationship) {
+    list($relationshipTypeId, $direction) = explode('_', $relatedRelationship);
+    if (empty($relationshipTypeId) || empty($direction)) {
+      return NULL;
+    }
+
+    $isAToB = $direction == 'ab';
+    $relationshipTable = CRM_Contact_BAO_Relationship::getTableName();
+    $relationshipTypeTable = CRM_Contact_BAO_RelationshipType::getTableName();
+    $contactTable = CRM_Contact_BAO_Contact::getTableName();
+    $relationshipJoinCondition = $isAToB ? 'ON r.contact_id_a = c.id' : 'ON r.contact_id_b = c.id';
+    $contactCondition = $isAToB ? 'AND r.contact_id_b = %1' : 'AND r.contact_id_a = %1';
+
+    $query = "
+      SELECT c.id
+      FROM {$contactTable } c
+      INNER JOIN {$relationshipTable} r
+       {$relationshipJoinCondition}
+      INNER JOIN {$relationshipTypeTable} rt
+        ON rt.id = r.relationship_type_id
+      WHERE r.is_active = 1 AND rt.is_active = 1
+      AND rt.id = %2
+      {$contactCondition}
+      AND (r.start_date IS NULL OR r.start_date <= %3)
+      AND (r.end_date IS NULL OR r.end_date >= %3)
+      LIMIT 1;
+    ";
+
+    $params = [
+      1 => [$contactId, 'Integer'],
+      2 => [$relationshipTypeId, 'Integer'],
+      3 => [date('Y-m-d'), 'String'],
+    ];
+
+    $result = CRM_Core_DAO::executeQuery($query, $params);
+    $contact = [];
+
+    while ($result->fetch()) {
+      $contact = [
+        'id' => $result->id,
+      ];
+    }
+
+    return !empty($contact['id']) ? $contact['id'] : NULL;
+  }
+
+}

--- a/CRM/Contactlayout/Page/Inline/ProfileBlock.php
+++ b/CRM/Contactlayout/Page/Inline/ProfileBlock.php
@@ -4,8 +4,10 @@ use CRM_Contactlayout_ExtensionUtil as E;
 class CRM_Contactlayout_Page_Inline_ProfileBlock extends CRM_Core_Page {
 
   public function run() {
-    $contactId = CRM_Utils_Request::retrieveValue('cid', 'Positive', NULL, TRUE);
+    $viewedContactId = CRM_Utils_Request::retrieveValue('cid', 'Positive', NULL, TRUE);
     $profileId = CRM_Utils_Request::retrieveValue('gid', 'Positive', NULL, TRUE);
+    $relatedContactId = CRM_Utils_Request::retrieveValue('rel_cid', 'Positive', NULL, FALSE);
+    $contactId = $relatedContactId ? $relatedContactId : $viewedContactId;
 
     $this->assign('contactId', $contactId);
     $this->assign('profileBlock', self::getProfileBlock($profileId, $contactId));

--- a/contactlayout.php
+++ b/contactlayout.php
@@ -2,6 +2,7 @@
 
 require_once 'contactlayout.civix.php';
 use CRM_Contactlayout_ExtensionUtil as E;
+use CRM_Contactlayout_Helper_ProfileRelatedContact as ProfileRelatedContact;
 
 /**
  * Implements hook_civicrm_config().
@@ -133,11 +134,14 @@ function contactlayout_civicrm_pageRun(&$page) {
       $layout = CRM_Contactlayout_BAO_ContactLayout::getLayout($contactID);
       if ($layout) {
         $profileBlocks = [];
-        foreach ($layout['blocks'] as $row) {
-          foreach ($row as $column) {
-            foreach ($column as $block) {
+        foreach ($layout['blocks'] as &$row) {
+          foreach ($row as &$column) {
+            foreach ($column as &$block) {
               if (!empty($block['profile_id'])) {
-                $profileBlocks[$block['profile_id']] = CRM_Contactlayout_Page_Inline_ProfileBlock::getProfileBlock($block['profile_id'], $contactID);
+                $relatedContact = ProfileRelatedContact::get($contactID, !empty($block['related_rel']) ? $block['related_rel'] : '');
+                $profileContact = $relatedContact ? $relatedContact : $contactID;
+                $profileBlocks[$block['profile_id']] = CRM_Contactlayout_Page_Inline_ProfileBlock::getProfileBlock($block['profile_id'], $profileContact);
+                $block['rel_cid'] = $relatedContact;
               }
             }
           }

--- a/templates/CRM/Contactlayout/Page/Inline/Profile.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/Profile.tpl
@@ -1,2 +1,2 @@
 {assign var='profileId' value=$block.profile_id}
-{include file="CRM/Contactlayout/Page/Inline/ProfileBlock.tpl" profileBlock=$profileBlocks.$profileId}
+{include file="CRM/Contactlayout/Page/Inline/ProfileBlock.tpl" profileBlock=$profileBlocks.$profileId relatedContact=$block.rel_cid}

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -1,4 +1,10 @@
-<div id="{$block.selector|replace:'#':''}" {if $permission EQ 'edit'} class="crm-inline-edit" data-dependent-fields={$block.refresh|@json_encode} data-edit-params='{ldelim}"cid": "{$contactId}", "rel_cid": "{$relatedContact}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}' {/if}>
+<div id="{$block.selector|replace:'#':''}"
+  {if $permission EQ 'edit'}
+    class="crm-inline-edit"
+    data-dependent-fields={$block.refresh|@json_encode}
+    data-edit-params='{ldelim}"cid": "{$contactId}", "rel_cid": "{$relatedContact}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}'
+  {/if}
+>
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -1,4 +1,4 @@
-<div id="{$block.selector|replace:'#':''}" {if $permission EQ 'edit'} class="crm-inline-edit" data-dependent-fields={$block.refresh|@json_encode} data-edit-params='{ldelim}"cid": "{$contactId}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}' {/if}>
+<div id="{$block.selector|replace:'#':''}" {if $permission EQ 'edit'} class="crm-inline-edit" data-dependent-fields={$block.refresh|@json_encode} data-edit-params='{ldelim}"cid": "{$contactId}", "rel_cid": "{$relatedContact}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}' {/if}>
   <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
     {if $permission EQ 'edit'}
       <div class="crm-edit-help">


### PR DESCRIPTION
## Overview
This PR adds the necessary backend changes that allows a profile block to load information for a relationship contact when available for the block. 
Currently the profile block will only load data for the currently viewed contact in the contact summary page but with proposed changes to FE, a profile block can be associated with a relationship and the the contact that has the relationship with the currently viewed contact is the related contact.


## Before
This functionality is not available.

## After
This functionality is available

## Technical Details
- The `CRM_Contactlayout_Helper_ProfileRelatedContact` helper class was added to help in retrieving the related contact information based on the currently viewed contact and the related relationship set for the block.
- In the `CRM_Contactlayout_Page_Inline_ProfileBlock` Profile block view class page and the Profile block edit form page class `CRM_Contactlayout_Form_Inline_ProfileBlock`, the related contact is set in place of the viewed contact if available.
