### PR TITLE
CATL-1380: Create relationship block

### DIFF
--- a/CRM/Contactlayout/Form/RelationshipSelection.php
+++ b/CRM/Contactlayout/Form/RelationshipSelection.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * Relationship Selection Form controller class
+ */
+class CRM_Contactlayout_Form_RelationshipSelection extends CRM_Core_Form {
+
+  /**
+   * Adds the relationship selection field and the save and cancel button.
+   *
+   * @inheritDoc
+   */
+  public function buildQuickForm() {
+    $relationshipOptions = $this->getRelationshipOptions();
+    asort($relationshipOptions);
+
+    $this->add(
+      'select',
+      'related_rel',
+      ts('Relationship'),
+      $relationshipOptions,
+      FALSE,
+      [
+        'class' => 'crm-select2',
+        'placeholder' => ts('- select - '),
+      ]
+    );
+
+    $this->addButtons([
+      [
+        'type' => 'upload',
+        'name' => ts('Save'),
+        'isDefault' => TRUE,
+      ],
+      [
+        'type' => 'cancel',
+        'name' => ts('Cancel'),
+      ],
+    ]);
+
+    parent::buildQuickForm();
+  }
+
+  /**
+   * Attaches the selected relationship value to the AJAX response object of the form.
+   *
+   * @inheritDoc
+   */
+  public function postProcess() {
+    $values = $this->exportValues();
+    $this->ajaxResponse = [
+      'values' => [
+        'related_rel' => $values['related_rel'],
+      ],
+    ];
+  }
+
+  /**
+   * Accepts a default value for the relationship field.
+   *
+   * The value can come from a GET request parameter.
+   *
+   * @inheritDoc
+   */
+  public function setDefaultValues() {
+    $defaults = parent::setDefaultValues();
+
+    $defaults['related_rel'] = CRM_Utils_Request::retrieve('related_rel', 'String');;
+
+    return $defaults;
+  }
+
+  /**
+   * Returns all defined relationships, including both directions.
+   *
+   * The relationships are returned in a format that can be accepted by select fields.
+   * We include both directions of the relationship. Ex: 16_ab "Parent of" and 16_ba
+   * "Child Of".
+   *
+   * @return array
+   *   A list of relationship option values.
+   */
+  private function getRelationshipOptions() {
+    $relationshipOptions = [];
+    $relationships = civicrm_api3('RelationshipType', 'get', [
+      'sequential' => 1,
+      'options' => [
+        'limit' => 0,
+      ],
+    ]);
+
+    foreach($relationships['values'] as $relationship) {
+      $relationshipOptions[$relationship['id'] . '_ab'] = $relationship['label_a_b'];
+      $relationshipOptions[$relationship['id'] . '_ba'] = $relationship['label_b_a'];
+    }
+
+    return $relationshipOptions;
+  }
+
+}

--- a/CRM/Contactlayout/Form/RelationshipSelection.php
+++ b/CRM/Contactlayout/Form/RelationshipSelection.php
@@ -7,8 +7,6 @@ class CRM_Contactlayout_Form_RelationshipSelection extends CRM_Core_Form {
 
   /**
    * Adds the relationship selection field and the save and cancel button.
-   *
-   * @inheritDoc
    */
   public function buildQuickForm() {
     $relationshipOptions = $this->getRelationshipOptions();
@@ -43,8 +41,6 @@ class CRM_Contactlayout_Form_RelationshipSelection extends CRM_Core_Form {
 
   /**
    * Attaches the selected relationship value to the AJAX response object of the form.
-   *
-   * @inheritDoc
    */
   public function postProcess() {
     $values = $this->exportValues();
@@ -59,8 +55,6 @@ class CRM_Contactlayout_Form_RelationshipSelection extends CRM_Core_Form {
    * Accepts a default value for the relationship field.
    *
    * The value can come from a GET request parameter.
-   *
-   * @inheritDoc
    */
   public function setDefaultValues() {
     $defaults = parent::setDefaultValues();

--- a/ang/contactlayout/contactlayout.js
+++ b/ang/contactlayout/contactlayout.js
@@ -131,6 +131,21 @@
       }
     };
 
+    /**
+     * Opens a modal that allows editing the relationship field for the given block.
+     *
+     * @param {object} block a contact layout block object.
+     */
+    $scope.editBlockRelationship = function(block) {
+      CRM.loadForm(CRM.url('civicrm/contact-layout/select-relationship', {
+        related_rel: block.related_rel
+      }))
+        .on('crmFormSuccess', (event, response) => {
+          block.related_rel = response.values.related_rel;
+          $scope.$digest();
+        });
+    };
+
     $scope.addRow = function() {
       $scope.selectedLayout.blocks.push([[], []]);
     };
@@ -348,7 +363,7 @@
 
     // Return the editable properties of a block
     function getBlockProperties(block) {
-      return _.pick(block, 'name', 'title', 'collapsible', 'collapsed', 'showTitle');
+      return _.pick(block, 'name', 'title', 'collapsible', 'collapsed', 'showTitle', 'related_rel');
     }
 
     // Write layout data to the server

--- a/ang/contactlayout/contactlayoutblock.html
+++ b/ang/contactlayout/contactlayoutblock.html
@@ -7,6 +7,14 @@
   <button class="btn btn-success-outline" ng-if="block.edit" ng-click="editBlock(block)" title="{{ ts('Edit block') }}">
     <i class="crm-i fa-pencil"></i>
   </button>
+  <button
+    class="btn btn-success-outline"
+    title="{{ ts('Select relationship') }}"
+    ng-if="block.edit"
+    ng-click="editBlockRelationship(block)"
+  >
+    <i class="crm-i fa-users" ng-class="{'text-primary': !!block.related_rel}"></i>
+  </button>
   <button class="btn btn-danger-outline" ng-if="col" ng-click="removeBlock($index, col)" title="{{ ts('Remove block') }}">
     <i class="crm-i fa-close"></i>
   </button>

--- a/contactlayout.php
+++ b/contactlayout.php
@@ -152,10 +152,14 @@ function contactlayout_civicrm_pageRun(&$page) {
                 $block['rel_is_missing'] = $relatedContact === NULL;
               }
 
-              $profileBlocks[$block['profile_id']] = CRM_Contactlayout_Page_Inline_ProfileBlock::getProfileBlock(
-                $block['profile_id'],
-                $profileContact
-              );
+              // Include the block information only when there is a contact profile to display.
+              // This can be empty when there are no results for a particular relationship block.
+              if (!empty($profileContact)) {
+                $profileBlocks[$block['profile_id']] = CRM_Contactlayout_Page_Inline_ProfileBlock::getProfileBlock(
+                  $block['profile_id'],
+                  $profileContact
+                );
+              }
             }
           }
         }

--- a/contactlayout.php
+++ b/contactlayout.php
@@ -143,13 +143,13 @@ function contactlayout_civicrm_pageRun(&$page) {
 
               $profileContact = $contactID;
               $block['rel_cid'] = NULL;
-              $block['rel_isMissing'] = FALSE;
+              $block['rel_is_missing'] = FALSE;
 
               if (!empty($block['related_rel'])) {
                 $relatedContact = ProfileRelatedContact::get($contactID, $block['related_rel']);
                 $profileContact = $relatedContact;
                 $block['rel_cid'] = $relatedContact;
-                $block['rel_isMissing'] = $relatedContact === NULL;
+                $block['rel_is_missing'] = $relatedContact === NULL;
               }
 
               $profileBlocks[$block['profile_id']] = CRM_Contactlayout_Page_Inline_ProfileBlock::getProfileBlock(

--- a/contactlayout.php
+++ b/contactlayout.php
@@ -137,12 +137,25 @@ function contactlayout_civicrm_pageRun(&$page) {
         foreach ($layout['blocks'] as &$row) {
           foreach ($row as &$column) {
             foreach ($column as &$block) {
-              if (!empty($block['profile_id'])) {
-                $relatedContact = ProfileRelatedContact::get($contactID, !empty($block['related_rel']) ? $block['related_rel'] : '');
-                $profileContact = $relatedContact ? $relatedContact : $contactID;
-                $profileBlocks[$block['profile_id']] = CRM_Contactlayout_Page_Inline_ProfileBlock::getProfileBlock($block['profile_id'], $profileContact);
-                $block['rel_cid'] = $relatedContact;
+              if (empty($block['profile_id'])) {
+                continue;
               }
+
+              $profileContact = $contactID;
+              $block['rel_cid'] = NULL;
+              $block['rel_isMissing'] = FALSE;
+
+              if (!empty($block['related_rel'])) {
+                $relatedContact = ProfileRelatedContact::get($contactID, $block['related_rel']);
+                $profileContact = $relatedContact;
+                $block['rel_cid'] = $relatedContact;
+                $block['rel_isMissing'] = $relatedContact === NULL;
+              }
+
+              $profileBlocks[$block['profile_id']] = CRM_Contactlayout_Page_Inline_ProfileBlock::getProfileBlock(
+                $block['profile_id'],
+                $profileContact
+              );
             }
           }
         }

--- a/templates/CRM/Contactlayout/Form/RelationshipSelection.tpl
+++ b/templates/CRM/Contactlayout/Form/RelationshipSelection.tpl
@@ -1,0 +1,15 @@
+<div class="crm-container">
+  <div class="crm-section">
+    <div class="label">{$form.related_rel.label}</div>
+    <div class="content">
+      {$form.related_rel.html}
+      {$form.related_rel.description}
+      <p>If a relationship is selected, we display the information for the contact's
+      relation instead.</p>
+    </div>
+    <div class="clear"></div>
+  </div>
+  <div class="crm-submit-buttons">
+   {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
+</div>

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -1,35 +1,47 @@
 <div id="{$block.selector|replace:'#':''}"
-  {if $permission EQ 'edit'}
+  {if $permission EQ 'edit' && !$block.rel_isMissing}
     class="crm-inline-edit"
     data-dependent-fields={$block.refresh|@json_encode}
     data-edit-params='{ldelim}"cid": "{$contactId}", "rel_cid": "{$relatedContact}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}'
   {/if}
 >
-  <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
-    {if $permission EQ 'edit'}
-      <div class="crm-edit-help">
-        <span class="crm-i fa-pencil"></span> {ts}Edit{/ts}
-      </div>
-    {/if}
-    {foreach from=$profileBlock item='profileRow'}
-      <div class="crm-summary-row profile-block-{$profileRow.name}">
-        <div class="crm-label">{$profileRow.label|escape}</div>
-        <div class="crm-content">
-          {if $profileRow.name == 'tag'}
-            {foreach from=$contactTag item=tagName key=tagId}
-              <span class="crm-tag-item" {if !empty($allTags.$tagId.color)}style="background-color: {$allTags.$tagId.color}; color: {$allTags.$tagId.color|colorContrast};"{/if} title="{$allTags.$tagId.description|escape}">
-                {$tagName}
-              </span>
-            {/foreach}
-          {elseif $profileRow.name == 'image_URL' && !empty($imageURL)}
-            <div id="crm-contact-thumbnail">
-              {include file="CRM/Contact/Page/ContactImage.tpl"}
-            </div>
-          {else}
-            {$profileRow.value|purify}
-          {/if}
+  {if !$block.rel_isMissing}
+    <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
+      {if $permission EQ 'edit'}
+        <div class="crm-edit-help">
+          <span class="crm-i fa-pencil"></span> {ts}Edit{/ts}
         </div>
-      </div>
-    {/foreach}
-  </div>
+      {/if}
+      {foreach from=$profileBlock item='profileRow'}
+        <div class="crm-summary-row profile-block-{$profileRow.name}">
+          <div class="crm-label">{$profileRow.label|escape}</div>
+          <div class="crm-content">
+            {if $profileRow.name == 'tag'}
+              {foreach from=$contactTag item=tagName key=tagId}
+                <span class="crm-tag-item" {if !empty($allTags.$tagId.color)}style="background-color: {$allTags.$tagId.color}; color: {$allTags.$tagId.color|colorContrast};"{/if} title="{$allTags.$tagId.description|escape}">
+                  {$tagName}
+                </span>
+              {/foreach}
+            {elseif $profileRow.name == 'image_URL' && !empty($imageURL)}
+              <div id="crm-contact-thumbnail">
+                {include file="CRM/Contact/Page/ContactImage.tpl"}
+              </div>
+            {else}
+              {$profileRow.value|purify}
+            {/if}
+          </div>
+        </div>
+      {/foreach}
+    </div>
+  {else}
+    <div class="crm-clear crm-inline-block-content">
+      <h4>No relationship found.</h4>
+      <p>
+        <a href="{crmURL p='civicrm/contact/view/rel' q="reset=1&cid=`$block.profile_id`"}">
+          Click here
+        </a>
+        to view relationships.
+      </p>
+    </div>
+  {/if}
 </div>

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -37,7 +37,7 @@
     <div class="crm-clear crm-inline-block-content">
       <h4>No relationship found.</h4>
       <p>
-        <a href="{crmURL p='civicrm/contact/view/rel' q="reset=1&cid=`$block.profile_id`"}">
+        <a href="{crmURL p='civicrm/contact/view' q="reset=1&selectedChild=rel&cid=`$contactId`"}">
           Click here
         </a>
         to view relationships.

--- a/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
+++ b/templates/CRM/Contactlayout/Page/Inline/ProfileBlock.tpl
@@ -1,11 +1,11 @@
 <div id="{$block.selector|replace:'#':''}"
-  {if $permission EQ 'edit' && !$block.rel_isMissing}
+  {if $permission EQ 'edit' && !$block.rel_is_missing}
     class="crm-inline-edit"
     data-dependent-fields={$block.refresh|@json_encode}
     data-edit-params='{ldelim}"cid": "{$contactId}", "rel_cid": "{$relatedContact}", "gid": {$block.profile_id}, "class_name": "CRM_Contactlayout_Form_Inline_ProfileBlock"{rdelim}'
   {/if}
 >
-  {if !$block.rel_isMissing}
+  {if !$block.rel_is_missing}
     <div class="crm-clear crm-inline-block-content" {if $permission EQ 'edit'}title="{ts}Edit{/ts}"{/if}>
       {if $permission EQ 'edit'}
         <div class="crm-edit-help">

--- a/xml/Menu/contactlayout.xml
+++ b/xml/Menu/contactlayout.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<menu>
+  <item>
+    <path>civicrm/contact-layout/select-relationship</path>
+    <page_callback>CRM_Contactlayout_Form_RelationshipSelection</page_callback>
+    <title>Relationship Selection</title>
+    <access_arguments>access CiviCRM</access_arguments>
+  </item>
+</menu>


### PR DESCRIPTION
## Overview
This PR introduces the following changes:

* It allows the user to select a relationship to display in a summary block. When a relationship is selected, we display the relation's information instead of the contact's information.
* We added a "no relationship found" message when there is no relation to the contact for the given relationship. Example: the contact didn't have a case coordinator.

## Before & After

### Relationship selection
#### Before
![Screen Shot 2020-05-26 at 5 27 47 AM](https://user-images.githubusercontent.com/1642119/82884402-aa618680-9f11-11ea-9763-cc8ac3d43479.png)
The relationship can't be selected.

#### After
![gif](https://user-images.githubusercontent.com/1642119/82884928-720e7800-9f12-11ea-8e00-9e469861359a.gif)

### No relationship message
#### Before
![Screen Shot 2020-05-26 at 5 23 25 AM](https://user-images.githubusercontent.com/1642119/82883911-10014300-9f11-11ea-8473-78e6c9d9e1c6.png)
We used to display the contact's own information instead of the relation information.

#### After
![Screen Shot 2020-05-26 at 5 22 18 AM](https://user-images.githubusercontent.com/1642119/82883930-14c5f700-9f11-11ea-911b-6d2aec0a85b8.png)
Note: it's the same contact because contacts can have relationships to themselves.

## Technical details

We created a new `RelationshipSelection` form that helps us select the relationship. This form was created using [civix](https://docs.civicrm.org/dev/en/latest/extensions/civix/#generate-form). We added the relationship selection field and a save and cancel buttons on `buildQuickForm`. When we load the form we use `setDefaultValues` to capture a default value for the relationship field in case there was one already selected. The `postProcess` method allows us to return the selected relationship through an ajax response object. This is used by Angular to determine if a relationship was selected or not.

We modified `contactlayout.js` so it includes a `editBlockRelationship` method that opens the relationship selection form and listens for its submission event in order to capture the selected value.

In `contactlayoutblock.html` we implemented the new `editBlockRelationship` method to trigger opening the form through an icon placed on the block, but also mark this icon as `primary` if there is a relationship selected.

Finally, both `contactlayout.php` and `ProfileBlock.tpl` were updated so we take into consideration the scenario where the contact has no relation for the selected relationship type.